### PR TITLE
Support external graphql plugins

### DIFF
--- a/gatsby-node.ts
+++ b/gatsby-node.ts
@@ -11,12 +11,10 @@ import { GatsbyNode } from 'gatsby';
 // @ts-ignore
 import { graphql, introspectionQuery } from 'gatsby/graphql';
 // @ts-ignore
-import getGatsbyDependents from "gatsby/dist/utils/gatsby-dependents.js"
-// @ts-ignore
-import report from "gatsby-cli/lib/reporter"
-import glob from "glob"
-import normalize from "normalize-path"
-import _ from "lodash"
+import getGatsbyDependents from 'gatsby/dist/utils/gatsby-dependents';
+import glob from 'glob';
+import normalize from 'normalize-path';
+import _ from 'lodash';
 
 import { PluginOptions } from './types';
 
@@ -73,7 +71,7 @@ const STATIC_QUERY_COMPONENT_REPLACER = (substring: string, ...args: any[]): str
   return substring.replace(groups['JsxTagOpening'], `<StaticQuery<${groups['QueryName']}Query>`);
 }
 
-export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({ store }, options) => {
+export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({ store, reporter }, options) => {
   const {
     schemaOutputPath = DEFAULT_SCHEMA_OUTPUT_PATH,
     typeDefsOutputPath = DEFAULT_TYPE_DEFS_OUTPUT_PATH,
@@ -171,10 +169,10 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({ store }, 
   };
 
   // Wait for first extraction
-  const docLookupActivity = report.activityTimer(
+  const docLookupActivity = reporter.activityTimer(
     `lookup graphql documents for type generation`,
     {
-      id: `query-codegen-doc-lookup`,
+      parentSpan: {},
     }
   );
   docLookupActivity.start();
@@ -206,10 +204,10 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({ store }, 
   };
 
   const writeTypeDefinition = debounce(async () => {
-    const generateSchemaActivity = report.activityTimer(
+    const generateSchemaActivity = reporter.activityTimer(
       `generate graphql typescript`,
       {
-        id: `query-codegen-schema`,
+        parentSpan: {},
       }
     );
     generateSchemaActivity.start();

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
     "@graphql-codegen/core": "^1.7.0",
     "@graphql-codegen/typescript": "^1.7.0",
     "@graphql-codegen/typescript-operations": "^1.7.0",
-    "@types/normalize-path": "^3.0.0",
     "chokidar": "^3.0.2",
     "graphql-toolkit": "^0.5.11",
     "lodash": "^4.17.15",
@@ -48,6 +47,7 @@
     "@types/graphql": "^14.5.0",
     "@types/lodash.debounce": "^4.0.6",
     "@types/node": "^12.7.3",
+    "@types/normalize-path": "^3.0.0",
     "babel-preset-gatsby-package": "^0.2.3",
     "gatsby": "^2.15.6",
     "typescript": "^3.5.3"

--- a/package.json
+++ b/package.json
@@ -25,15 +25,19 @@
   ],
   "peerDependencies": {
     "gatsby": ">=2.0.0",
+    "gatsby-cli": ">=2.0.0",
     "graphql": "^0.13.0 || ^14.0.0"
   },
   "dependencies": {
     "@graphql-codegen/core": "^1.7.0",
     "@graphql-codegen/typescript": "^1.7.0",
     "@graphql-codegen/typescript-operations": "^1.7.0",
+    "@types/normalize-path": "^3.0.0",
     "chokidar": "^3.0.2",
     "graphql-toolkit": "^0.5.11",
-    "lodash.debounce": "^4.0.8"
+    "lodash": "^4.17.15",
+    "lodash.debounce": "^4.0.8",
+    "normalize-path": "^3.0.0"
   },
   "devDependencies": {
     "@babel/cli": "^7.6.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1184,6 +1184,11 @@
   resolved "https://registry.yarnpkg.com/@types/node/-/node-7.10.7.tgz#8604623912010235185f1166c7a5a9aa7de9fcd8"
   integrity sha512-4I7+hXKyq7e1deuzX9udu0hPIYqSSkdKXtjow6fMnQ3OR9qkxIErGHbGY08YrfZJrCS1ajK8lOuzd0k3n2WM4A==
 
+"@types/normalize-path@^3.0.0":
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/@types/normalize-path/-/normalize-path-3.0.0.tgz#bb5c46cab77b93350b4cf8d7ff1153f47189ae31"
+  integrity sha512-Nd8y/5t/7CRakPYiyPzr/IAfYusy1FkcZYFEAcoMZkwpJv2n4Wm+olW+e7xBdHEXhOnWdG9ddbar0gqZWS4x5Q==
+
 "@types/prop-types@*":
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/@types/prop-types/-/prop-types-15.7.2.tgz#0e58ae66773d7fd7c372a493aff740878ec9ceaa"


### PR DESCRIPTION
Fixes issue #3 and issue #7 by replicating  in the context of this plugin

A key discovery was this issue:
https://github.com/gatsbyjs/gatsby/issues/5663

Which pointed me to the file
https://github.com/gatsbyjs/gatsby/blob/2.13.30/packages/gatsby/src/query/query-compiler.js

By duplicating that code into this plugin we have mostly the same file resolution and should discover any fragments that gatsby can