### PR TITLE
Export Fragment Subtypes

### DIFF
--- a/src/workers/codegen.ts
+++ b/src/workers/codegen.ts
@@ -72,7 +72,12 @@ export const setupCodegenWorker: SetupCodegenWorkerFn = ({
       codegenOptions.pluginMap['typescript'] = require('@graphql-codegen/typescript');
       codegenOptions.plugins.push({ typescript: DEFAULT_TYPESCRIPT_CONFIG });
       codegenOptions.pluginMap['typescriptOperations'] = require('@graphql-codegen/typescript-operations');
-      codegenOptions.plugins.push({ typescriptOperations: DEFAULT_TYPESCRIPT_CONFIG });
+      codegenOptions.plugins.push({
+        typescriptOperations: {
+          ...DEFAULT_TYPESCRIPT_CONFIG,
+          exportFragmentSpreadSubTypes: true
+        }
+      });
       if (includeResolvers) {
         codegenOptions.pluginMap['typescriptResolvers'] = require('@graphql-codegen/typescript-resolvers');
         codegenOptions.plugins.push({

--- a/src/workers/codegen.ts
+++ b/src/workers/codegen.ts
@@ -90,7 +90,12 @@ export const setupCodegenWorker: SetupCodegenWorkerFn = ({
       codegenOptions.pluginMap['flow'] = require('@graphql-codegen/flow');
       codegenOptions.plugins.push({ flow: DEFAULT_FLOW_CONFIG });
       codegenOptions.pluginMap['flowOperations'] = require('@graphql-codegen/flow-operations');
-      codegenOptions.plugins.push({ flowOperations: DEFAULT_FLOW_CONFIG });
+      codegenOptions.plugins.push({
+        flowOperations: {
+          ...DEFAULT_FLOW_CONFIG,
+          exportFragmentSpreadSubTypes: true
+        }
+      });
       if (includeResolvers) {
         codegenOptions.pluginMap['flowResolvers'] = require('@graphql-codegen/flow-resolvers');
         // Where is contextType option????? WHERE


### PR DESCRIPTION
closes #45 

I kind of assume there's a way to override this in a config file, but I couldn't figure it out in the limited time I have, so I did a quick publish to `@nmbl/gatsby-plugin-typegen` to prototype until the author provides a workaround or accepts this PR.