### PR TITLE
Using global declarations with namespace instead of using module

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,6 +209,10 @@ Or [gatsby-plugin-graphql-codegen](https://github.com/d4rekanguok/gatsby-typescr
 
 ## Changelog
 
+### v2.0.0
+
+- **[BREAKING CHANGE]** Generated types are now using global declaration with a namespace (default is `GatsbyTypes`).
+
 ### v1.1.2
 
 - Export inline fragment subtypes. ([#45](https://github.com/cometkim/gatsby-plugin-typegen/issues/45))

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -79,7 +79,8 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
   reporter,
 }) => {
   const {
-    language,
+    languageOption,
+    languageOption: { language },
     outputPath,
     includeResolvers,
     emitSchema,
@@ -129,7 +130,7 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
 
   const codegenWorker = setupCodegenWorker({
     schemaAst: schema,
-    language,
+    languageOption,
     outputPath,
     includeResolvers,
     reporter,
@@ -178,12 +179,12 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
 
       pushCodegenTask();
 
-      if (pluginOptions.language === 'typescript' && /\.tsx?$/.test(componentPath)) {
+      if (language === 'typescript' && /\.tsx?$/.test(componentPath)) {
         pushInsertTypeTask({ file: componentPath });
       }
 
       // Flow version is bit more slower because should check the `@flow` comment exist.
-      if (pluginOptions.language === 'flow' && /\.jsx?$/.test(componentPath)) {
+      if (language === 'flow' && /\.jsx?$/.test(componentPath)) {
         const content = await readFile(componentPath);
         const hasFlowComment = content.includes('@flow');
         reporter.verbose(`[typegen] Check if the file has flow comment: ${hasFlowComment}`);

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -79,8 +79,8 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
   reporter,
 }) => {
   const {
-    languageOption,
-    languageOption: { language },
+    language,
+    namespace,
     outputPath,
     includeResolvers,
     emitSchema,
@@ -130,7 +130,8 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
 
   const codegenWorker = setupCodegenWorker({
     schemaAst: schema,
-    languageOption,
+    language,
+    namespace,
     outputPath,
     includeResolvers,
     reporter,
@@ -147,7 +148,11 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
   if (process.env.NODE_ENV === 'development') {
     reporter.verbose('[typegen][dev] Watching query changes and re-run workers');
 
-    const insertTypeWorker = autoFix && setupInsertTypeWorker({ reporter });
+    const insertTypeWorker = autoFix && setupInsertTypeWorker({
+      language,
+      namespace,
+      reporter,
+    });
     const pushInsertTypeTask = (task: InsertTypeTask) => {
       if (!insertTypeWorker) {
         return;

--- a/src/plugin-utils.ts
+++ b/src/plugin-utils.ts
@@ -56,6 +56,7 @@ export const requirePluginOptions: RequirePluginOptionsFn = (
     emitPluginDocuments = {},
     schemaOutputPath,
     typeDefsOutputPath,
+    declarationConfig,
   } = pluginOptions;
 
   const emitSchema: MapTrueToDefault<typeof emitSchemaOptionMap> = {};

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,5 +1,9 @@
 /* @flow */
 
+type GatsbyTypes$Asdf = {
+
+};
+
 export type PluginOptions = {
 
   /**
@@ -8,6 +12,11 @@ export type PluginOptions = {
    * @default 'typescript'
    */
   language?: 'typescript' | 'flow',
+
+  /**
+   *
+   */
+  declarationConfig?: DeclarationConfigOptions;
 
   /**
    * Path to save generated typeDefs file.
@@ -81,6 +90,37 @@ export type SchemaOutputOptions = {
    */
   commentDescriptions?: boolean,
 };
+
+export type DeclarationConfigOptions = {
+  kind: 'type' | 'interface',
+} & (
+  | {
+    scope: 'module',
+
+    /**
+     * @default undefined
+     */
+    prefix?: string;
+  }
+  | {
+    scope: 'namespace',
+
+    /**
+     * @default 'GatsbyTypes'
+     */
+    namespace?: string,
+
+    /**
+     * @default undefined
+     */
+    prefix?: string;
+
+  }
+  | {
+    scope: 'global',
+    prefix: string;
+  }
+);
 
 export type DeprecatedPluginOptions = {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -7,8 +7,17 @@ export type PluginOptions = {
    *
    * @default 'typescript'
    */
-  // language?: LanguageOptions | LanguageOptions['language'],
-  language?: LanguageOptions | 'typescript' | 'flow',
+  language?: 'typescript' | 'flow',
+
+  /**
+   * Namespace is required to avoid conflict on generated types and other global declarations.
+   *
+   * Flow will use $ prefix as fallback.
+   * e.g) `type GatsbyTypes$MySiteQuery = ...`
+   *
+   * @default 'GatsbyTypes'
+   */
+  namespace?: string;
 
   /**
    * Path to save generated typeDefs file.
@@ -82,62 +91,6 @@ export type SchemaOutputOptions = {
    */
   commentDescriptions?: boolean,
 };
-
-type ModuleScope = {
-  scope: 'module',
-
-  /**
-   * @default ''
-   */
-  prefix?: string;
-};
-
-type NamespaceScope = {
-  scope: 'namespace',
-
-  /**
-   * @default ''
-   */
-  prefix?: string;
-
-  /**
-   * @default 'GatsbyTypes'
-   */
-  namespace?: string;
-};
-
-type GlobalScope = {
-  scope: 'global',
-
-  /**
-   * Prefix is required for global scope declaration.
-   * Because there must be name conflict in generated type names.
-   */
-  prefix: string;
-};
-
-type LanguageScopeConfig = (
-  | ModuleScope
-  | NamespaceScope
-  | GlobalScope
-);
-
-export type LanguageOptions = {
-
-  /**
-   * Prefer TypeScript by default, but you can switch to flow.
-   *
-   * @default 'typescript'
-   */
-  language?: 'typescript' | 'flow',
-
-  /**
-   * Can specify the prefer syntax
-   *
-   * @default 'type'
-   */
-  kind?: 'type' | 'interface',
-} & LanguageScopeConfig;
 
 export type DeprecatedPluginOptions = {
   /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,9 +1,5 @@
 /* @flow */
 
-type GatsbyTypes$Asdf = {
-
-};
-
 export type PluginOptions = {
 
   /**
@@ -11,12 +7,8 @@ export type PluginOptions = {
    *
    * @default 'typescript'
    */
-  language?: 'typescript' | 'flow',
-
-  /**
-   *
-   */
-  declarationConfig?: DeclarationConfigOptions;
+  // language?: LanguageOptions | LanguageOptions['language'],
+  language?: LanguageOptions | 'typescript' | 'flow',
 
   /**
    * Path to save generated typeDefs file.
@@ -91,36 +83,61 @@ export type SchemaOutputOptions = {
   commentDescriptions?: boolean,
 };
 
-export type DeclarationConfigOptions = {
-  kind: 'type' | 'interface',
-} & (
-  | {
-    scope: 'module',
+type ModuleScope = {
+  scope: 'module',
 
-    /**
-     * @default undefined
-     */
-    prefix?: string;
-  }
-  | {
-    scope: 'namespace',
+  /**
+   * @default ''
+   */
+  prefix?: string;
+};
 
-    /**
-     * @default 'GatsbyTypes'
-     */
-    namespace?: string,
+type NamespaceScope = {
+  scope: 'namespace',
 
-    /**
-     * @default undefined
-     */
-    prefix?: string;
+  /**
+   * @default ''
+   */
+  prefix?: string;
 
-  }
-  | {
-    scope: 'global',
-    prefix: string;
-  }
+  /**
+   * @default 'GatsbyTypes'
+   */
+  namespace?: string;
+};
+
+type GlobalScope = {
+  scope: 'global',
+
+  /**
+   * Prefix is required for global scope declaration.
+   * Because there must be name conflict in generated type names.
+   */
+  prefix: string;
+};
+
+type LanguageScopeConfig = (
+  | ModuleScope
+  | NamespaceScope
+  | GlobalScope
 );
+
+export type LanguageOptions = {
+
+  /**
+   * Prefer TypeScript by default, but you can switch to flow.
+   *
+   * @default 'typescript'
+   */
+  language?: 'typescript' | 'flow',
+
+  /**
+   * Can specify the prefer syntax
+   *
+   * @default 'type'
+   */
+  kind?: 'type' | 'interface',
+} & LanguageScopeConfig;
 
 export type DeprecatedPluginOptions = {
   /**

--- a/src/workers/codegen.ts
+++ b/src/workers/codegen.ts
@@ -9,14 +9,8 @@ import { RequiredPluginOptions } from '../plugin-utils';
 
 const CARGO_DELAY = 1000 as const;
 
-// const TYPEDEF_EXPORT_NODE_REGEXP = /export((.*)(\{|;)($|\s))/g;
-// const TYPEDEF_EXPORT_NODE_REPLACER = 'declare$1';
-
-// const TYPEDEF_MAYBE_NODE_REGEXP = /.*(type Maybe)/;
-// const TYPEDEF_MAYBE_NODE_REPLACER = '$1';
-
-// const TYPEDEF_SCALARS_NODE_REGEXP = /.*(type Scalars)/;
-// const TYPEDEF_SCALARS_NODE_REPLACER = '$1';
+const TYPEDEF_EXPORT_NODE_REGEXP = /export type ((.*)(\{\|?|;)($|\s))/g;
+const TYPEDEF_EXPORT_NODE_REPLACER = 'declare type $1';
 
 // Preset configurations to ensure compatibility with Gatsby.
 const DEFAULT_SHARED_CONFIG = {
@@ -139,6 +133,8 @@ export const setupCodegenWorker: SetupCodegenWorkerFn = ({
 
       if (language === 'typescript') {
         result = `declare namespace ${namespace} {\n${result}\n}`;
+      } else /* flow */ {
+        result = result.replace(TYPEDEF_EXPORT_NODE_REGEXP, TYPEDEF_EXPORT_NODE_REPLACER)
       }
 
       result = '/* eslint-disable */\n\n' + result;

--- a/src/workers/insert-types.ts
+++ b/src/workers/insert-types.ts
@@ -2,6 +2,7 @@ import { Reporter } from 'gatsby';
 import { queue, AsyncQueue, asyncify } from 'async';
 
 import { readFile, writeFile } from '../common';
+import { RequiredPluginOptions } from '../plugin-utils';
 
 const CONCURRENCY = 2;
 
@@ -22,13 +23,9 @@ const CONCURRENCY = 2;
  * `)
  */
 const STATIC_QUERY_HOOK_REGEXP = /(?<CallExpressionName>useStaticQuery(?<TypeTemplate><(?<TypeArgument>\S*)>)?)\([\s\S]*?graphql(?<TemplateLiteral>`\s*?(?<QueryDefinitionStart>query (?<QueryName>\S*)[^{]{)[^`]*?`)/g
-const STATIC_QUERY_HOOK_REPLACER = (substring: string, ...args: any[]): string => {
-  const { length: l, [l - 1]: groups } = args;
-  return substring.replace(groups['CallExpressionName'], `useStaticQuery<${groups['QueryName']}Query>`);
-}
 
 /**
- * (?<JsxTagOpening><StaticQuery
+ * (?<JsxTagOpening><StaticQuer
  *   (?<TagTypeTemplate><
  *     (?<TagTypeArgument>\S+)
  *   >)?
@@ -46,10 +43,6 @@ const STATIC_QUERY_HOOK_REPLACER = (substring: string, ...args: any[]): string =
  * `)
  */
 const STATIC_QUERY_COMPONENT_REGEXP = /(?<JsxTagOpening><StaticQuery(?<TagTypeTemplate><(?<TagTypeArgument>\S+)>)?)[\s\S]+?query={[\s\S]*?graphql(?<TemplateLiteral>`\s*?(?<QueryDefinitionStart>query (?<QueryName>\S*)[^{]?\{)[^`]*`)/g
-const STATIC_QUERY_COMPONENT_REPLACER = (substring: string, ...args: any[]): string => {
-  const { length: l, [l - 1]: groups } = args;
-  return substring.replace(groups['JsxTagOpening'], `<StaticQuery<${groups['QueryName']}Query>`);
-}
 
 export type InsertTypeTask = {
   file: string,
@@ -60,18 +53,29 @@ export type InsertTypeWorker = AsyncQueue<InsertTypeTask>;
 interface SetupInsertTypeWorkerFn {
   (props: {
     reporter: Reporter,
+    language: RequiredPluginOptions['language'],
+    namespace: string,
   }): InsertTypeWorker;
 }
 export const setupInsertTypeWorker: SetupInsertTypeWorkerFn = ({
   reporter,
+  language,
+  namespace,
 }) => {
   const worker = queue<InsertTypeTask>(asyncify(async (task: InsertTypeTask) => {
     const { file } = task;
+    const accessor = language === 'typescript' ? '.' : '$';
 
     const content = await readFile(file);
     const fixed = content
-      .replace(STATIC_QUERY_HOOK_REGEXP, STATIC_QUERY_HOOK_REPLACER)
-      .replace(STATIC_QUERY_COMPONENT_REGEXP, STATIC_QUERY_COMPONENT_REPLACER)
+      .replace(STATIC_QUERY_HOOK_REGEXP, (substring: string, ...args: any[]): string => {
+        const { length: l, [l - 1]: groups } = args;
+        return substring.replace(groups['CallExpressionName'], `useStaticQuery<${namespace}${accessor}${groups['QueryName']}Query>`);
+      })
+      .replace(STATIC_QUERY_COMPONENT_REGEXP, (substring: string, ...args: any[]): string => {
+        const { length: l, [l - 1]: groups } = args;
+        return substring.replace(groups['JsxTagOpening'], `<StaticQuery<${namespace}${accessor}${groups['QueryName']}Query>`);
+      })
 
     if (content !== fixed) {
       reporter.verbose(`[typegen] Insert type definitions into ${file}\nbecause documents were changed.`);

--- a/src/workers/insert-types.ts
+++ b/src/workers/insert-types.ts
@@ -22,10 +22,10 @@ const CONCURRENCY = 2;
  *   [^`]*?
  * `)
  */
-const STATIC_QUERY_HOOK_REGEXP = /(?<CallExpressionName>useStaticQuery(?<TypeTemplate><(?<TypeArgument>\S*)>)?)\([\s\S]*?graphql(?<TemplateLiteral>`\s*?(?<QueryDefinitionStart>query (?<QueryName>\S*)[^{]{)[^`]*?`)/g
+const STATIC_QUERY_HOOK_REGEXP = /(?<CallExpressionName>useStaticQuery(?<TypeTemplate><(?<TypeArgument>\S*)>)?)\([\s\S]*?graphql(?<TemplateLiteral>`\s*?(?<QueryDefinitionStart>query (?<QueryName>\S*)[^{]{)[^`]*?`)/g;
 
 /**
- * (?<JsxTagOpening><StaticQuer
+ * (?<JsxTagOpening><StaticQuery
  *   (?<TagTypeTemplate><
  *     (?<TagTypeArgument>\S+)
  *   >)?
@@ -42,7 +42,7 @@ const STATIC_QUERY_HOOK_REGEXP = /(?<CallExpressionName>useStaticQuery(?<TypeTem
  *   [^`]*?
  * `)
  */
-const STATIC_QUERY_COMPONENT_REGEXP = /(?<JsxTagOpening><StaticQuery(?<TagTypeTemplate><(?<TagTypeArgument>\S+)>)?)[\s\S]+?query={[\s\S]*?graphql(?<TemplateLiteral>`\s*?(?<QueryDefinitionStart>query (?<QueryName>\S*)[^{]?\{)[^`]*`)/g
+const STATIC_QUERY_COMPONENT_REGEXP = /(?<JsxTagOpening><StaticQuery(?<TagTypeTemplate><(?<TagTypeArgument>\S+)>)?)[\s\S]+?query={[\s\S]*?graphql(?<TemplateLiteral>`\s*?(?<QueryDefinitionStart>query (?<QueryName>\S*)[^{]?\{)[^`]*`)/g;
 
 export type InsertTypeTask = {
   file: string,


### PR DESCRIPTION
### Summary

This PR makes generated types to the global declaration as default, so it can be used without manual imports.

#### BREAKING CHANGE

This also introduces the new option `namespace` (default is `GatsbyTypes`) that required to use typedefs as a declaration without type conflicts.

It doesn't allow undefined or empty string, after the upgrade, every typenames in your codebase will be changed by the namespace.

```tsx
import type { SEOQuery } from '~/src/__generated__/gatsby-types';

function SEO() {
  const data = useStaticQuery<SEOQuery>(
    graphql`
      query SEO { ... }
    `
  );
  ...
```

will be changed into 

```tsx
// no need to import the type
function SEO() {
  const data = useStaticQuery<GatsbyTypes.SEOQuery>(
    graphql`
      query SEO { ... }
    `
  );
  ...
```

#### Flow supports

Since flow doesn't have namespace syntax, It uses `$` as the fallback behavior.

#### Other approaches

I realized that making this the default behavior is making it simpler and able to fully replace more complicated approaches like auto-import.

Please let me know if you still need to use type definitions through modules.

-----

Closes #24
Closes #16