### PR TITLE
Insert types on first execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,8 +212,9 @@ Or [gatsby-plugin-graphql-codegen](https://github.com/d4rekanguok/gatsby-typescr
 ### v2.0.0
 
 - **[BREAKING CHANGE]** Generated types are now using global declaration with a namespace (default is `GatsbyTypes`).
+- Fixed an issue where the insert types function only worked when documents were changed. ([#43](https://github.com/cometkim/gatsby-plugin-typegen/issues/43))
 
-### v1.1.2
+## v1.1.2
 
 - Export inline fragment subtypes. ([#45](https://github.com/cometkim/gatsby-plugin-typegen/issues/45))
 - Insert eslint-disable comment on top of generated file. ([#37](https://github.com/cometkim/gatsby-plugin-typegen/issues/37))

--- a/src/workers/insert-types.ts
+++ b/src/workers/insert-types.ts
@@ -4,7 +4,7 @@ import { queue, AsyncQueue, asyncify } from 'async';
 import { readFile, writeFile } from '../common';
 import { RequiredPluginOptions } from '../plugin-utils';
 
-const CONCURRENCY = 2;
+const CONCURRENCY = 4;
 
 /**
  * (?<CallExpressionName>useStaticQuery


### PR DESCRIPTION
Fixed an issue where the insert types function only worked when documents were changed.

Closes #43