### PR TITLE
Fix multiple query definitions in plugin documents on Windows

### DIFF
--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -112,10 +112,14 @@ export const onPostBootstrap: GatsbyNode['onPostBootstrap'] = async ({
     await writeFile(schemaOutputPath, output);
   }
 
+  // Gatsby component paths have forward slashes.  The following filter
+  // doesn't work properly on Windows if the matched path uses backslashes
+  const srcPath = path.resolve(basePath, 'src').replace(/\\/g, '/');
+
   const pluginDocuments = Object.values(emitPluginDocuments).some(Boolean) && (
     stripIndent(
       Array.from(trackedSource.entries())
-        .filter(([componentPath]) => !componentPath.startsWith(path.resolve(basePath, 'src')))
+        .filter(([componentPath]) => !componentPath.startsWith(srcPath))
         .map(([, source]) => source.rawSDL)
         .join('\n'),
     )


### PR DESCRIPTION
This fixes the issue from #44 where query definitions from the `src` path were being loaded into the schema files defined by `emitPluginDocuments`, causing duplicate query errors when using the `vscode-apollo` plugin.

Gatsby uses forward slashes for `componentPath`, and the `src` path filter was using `path.resolve()`, which will use backslashes.  To fix this, I just replace all backslashes in `src` path with forward slashes.  The other way to do it would have been to normalize `componentPath`, but this way is less processing for the app to do (even though the processing time is negligible, really 🤷‍♂).