### PR TITLE
fix: use onPreBootstrap instead of onPreExtractQueries

### DIFF
--- a/README.md
+++ b/README.md
@@ -227,6 +227,10 @@ Or [gatsby-plugin-graphql-codegen](https://github.com/d4rekanguok/gatsby-typescr
 
 ## Changelog
 
+### v2.2.1
+
+- Fixes bug caused by upstream behavior change ([#93](https://github.com/cometkim/gatsby-plugin-typegen/issues/93))
+
 ### v2.2.0
 
 - Use union types instead of enum values ([#78](https://github.com/cometkim/gatsby-plugin-typegen/issues/78))

--- a/src/gatsby-node.ts
+++ b/src/gatsby-node.ts
@@ -43,19 +43,12 @@ export const onPreBootstrap: GatsbyNode['onPreBootstrap'] = ({
     '[typegen] Successfully validate your configuration.\n'
     + JSON.stringify(pluginOptions, null, 2),
   );
-};
-
-export const onPreExtractQueries: GatsbyNode['onPreExtractQueries'] = ({
-  store: _store,
-  reporter,
-}) => {
-  const store = _store as GatsbyStore;
 
   reporter.verbose('[typegen] Listen on query extraction');
 
   // eslint-disable-next-line @typescript-eslint/no-misused-promises
   unsubscribeQueryExtraction = store.subscribe(async () => {
-    const lastAction = store.getState().lastAction;
+    const { lastAction } = store.getState();
 
     if (lastAction.type !== 'QUERY_EXTRACTION_BABEL_SUCCESS') {
       return;


### PR DESCRIPTION
Fixes https://github.com/cometkim/gatsby-plugin-typegen/issues/93
See https://github.com/gatsbyjs/gatsby/pull/25378