### PR TITLE
Fix the link to plugin options types

### DIFF
--- a/plugin/README.md
+++ b/plugin/README.md
@@ -213,7 +213,7 @@ TODO: Add config example
 
 ## Available options
 
-Checkout the full documentation of plugin options from [`src/types.ts`](https://github.com/cometkim/gatsby-plugin-typegen/blob/master/src/types.ts).
+Checkout the full documentation of plugin options from [`src/types.ts`](https://github.com/cometkim/gatsby-plugin-typegen/blob/master/plugin/src/types.ts).
 
 ## Disclaimer
 


### PR DESCRIPTION
Time to get that Hacktoberfest T-Shirt 😂

`/plugin/` was missing from the URL, resulting in 404.