### PR TITLE
Allow React 17 as peer dependency

### DIFF
--- a/plugin/package.json
+++ b/plugin/package.json
@@ -35,7 +35,7 @@
   "peerDependencies": {
     "gatsby": ">=2.0.0",
     "graphql": "^0.13.0 || ^14.0.0 || ^15.0.0",
-    "react": "^16.4.2"
+    "react": "^16.4.2 || ^17.0.0"
   },
   "dependencies": {
     "@cometjs/core": "^0.2.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9631,7 +9631,7 @@ fsevents@^1.2.7:
   peerDependencies:
     gatsby: ">=2.0.0"
     graphql: ^0.13.0 || ^14.0.0 || ^15.0.0
-    react: ^16.4.2
+    react: ^16.4.2 || ^17.0.0
   languageName: unknown
   linkType: soft
 


### PR DESCRIPTION
`npm install` currently fails when using React 17, as this plugin hasn't listed it as an allowed peer dependency. This pull requests simply adds it. Since React 17 [doesn't contain big functional changes](https://reactjs.org/blog/2020/10/20/react-v17.html), this should all be smooth sailing.