### PR TITLE
Fix wrong namespaces in some type definitions when using flow

### DIFF
--- a/plugin/src/workers/codegen.ts
+++ b/plugin/src/workers/codegen.ts
@@ -136,14 +136,14 @@ export const setupCodegenWorker: SetupCodegenWorkerFn = ({
     } else /* flow */ {
       const flow: FlowPluginConfig = {
         ...DEFAULT_FLOW_CONFIG,
-        typesPrefix: `${namespace}$`,
+        typesPrefix: `${namespace}`,
       };
       codegenOptions.plugins.push({ flow });
       codegenOptions.pluginMap['flow'] = require('@graphql-codegen/flow') as CodegenPlugin;
 
       const flowOperations: FlowDocumentsPluginConfig = {
         ...DEFAULT_FLOW_OPERATIONS_CONFIG,
-        typesPrefix: `${namespace}$`,
+        typesPrefix: `${namespace}`,
       };
       codegenOptions.plugins.push({ flowOperations });
       codegenOptions.pluginMap['flowOperations'] = require('@graphql-codegen/flow-operations') as CodegenPlugin;
@@ -151,7 +151,7 @@ export const setupCodegenWorker: SetupCodegenWorkerFn = ({
       if (includeResolvers) {
         const flowResolvers: FlowPluginConfig = {
           ...DEFAULT_FLOW_RESOLVERS_CONFIG,
-          typesPrefix: `${namespace}$`,
+          typesPrefix: `${namespace}`,
         };
         codegenOptions.plugins.push({ flowResolvers });
         codegenOptions.pluginMap['flowResolvers'] = require('@graphql-codegen/flow-resolvers') as CodegenPlugin;


### PR DESCRIPTION
For some reason one of the codegen plugins is not happy with `$` type prefix, causing some types references to be generated without `$` in the prefix therefore the type is undefined. Example in my generated file:

```
// Type is declared with $ prefix
declare type $ContentJsonFieldsEnum = $Values<typeof $ContentJsonFieldsEnumValues>;


declare type $ContentJsonSortInput = {|
  fields?: ?Array<?ContentJsonFieldsEnum>, // Type is referenced without prefix
  order?: ?Array<?$SortOrderEnum>,
|};
```

removing `$` from typePrefix seems to solve the issue.